### PR TITLE
fix(simon): remove touchstart preventDefault that blocked click on touch devices

### DIFF
--- a/w/sm/index.html
+++ b/w/sm/index.html
@@ -527,9 +527,6 @@
 
         tiles.forEach(function(t) {
           t.addEventListener('click', handleTileClick);
-          t.addEventListener('touchstart', function(e) {
-            e.preventDefault();
-          }, { passive: false });
         });
 
         startBtn.addEventListener('click', startGame);


### PR DESCRIPTION
The touchstart handler called e.preventDefault() which blocks the click event from firing on iOS Safari. Desktop mouse bypasses touch events entirely, so it worked only on desktop.

CSS touch-action: manipulation already handles the 300ms tap delay, making the JS preventDefault() redundant and harmful.