### PR TITLE
fix(clock): audit - settings toggle, fullscreen, persistence, cleanup

### DIFF
--- a/w/lc/clock.html
+++ b/w/lc/clock.html
@@ -8,11 +8,11 @@
         <link rel="stylesheet" href="../../css/about-privacy.css">
         <script src="script.js"></script>        
     </head>
-    <div style="display: none;">
-        <h3>Local Clock</h3>
-        shows time in 24 hr format, based on device local time
-    </div>
     <body class="pitch-dark">
+        <div style="display: none;">
+            <h3>Local Clock</h3>
+            shows time in 24 hr format, based on device local time
+        </div>
         <div class="container">
             <!-- Clock display element -->
             <div id="clock" class="clock"></div>

--- a/w/lc/script.js
+++ b/w/lc/script.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const adjustFontSize = (e) => {
-        fontSize = e.target.value;
+        const fontSize = e.target.value;
         fontSizeValue.textContent = `${fontSize}px`;
         clock.style.fontSize = `${fontSize}px`;
         localStorage.setItem('fontSize', fontSize);
@@ -95,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     settingsButton.addEventListener('click', () => {
-        settingsPanel.style.display = settingsPanel.style.display === 'none' ? 'block' : 'none';
+        settingsPanel.style.display = settingsPanel.style.display === 'block' ? 'none' : 'block';
     });
 
     toggleFormatButton.addEventListener('click', toggleFormat);
@@ -109,24 +109,11 @@ document.addEventListener('DOMContentLoaded', () => {
         fontSizeValue.textContent = `${savedFontSize}px`;
         clock.style.fontSize = `${savedFontSize}px`;
     } else {
-        fontSizeSlider.value = 80;
-        fontSizeValue.textContent = '100px';
-        clock.style.fontSize = '100px';
+        fontSizeSlider.value = '80';
+        fontSizeValue.textContent = '80px';
+        clock.style.fontSize = '80px';
     }
 
     updateClock();
     setInterval(updateClock, 1000);
-
-    // Intersection Observer Example
-    const target = document.querySelector('#target-element');
-    if (target) {
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    console.log('Element is in view!');
-                }
-            });
-        }, { threshold: 0.5 });
-        observer.observe(target);
-    }
 });

--- a/w/lc/script.js
+++ b/w/lc/script.js
@@ -7,31 +7,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const fontSizeSlider = document.getElementById('font-size');
     const fontSizeValue = document.getElementById('font-size-value');
     const toggleFullscreenButton = document.getElementById('toggle-fullscreen');
-    const container = document.querySelector('.container');
     const footer = document.querySelector('footer');
 
     let is24HourFormat = true;
     let colorMode = 'pitch-dark';
     let dynamicColorInterval;
+    let prevPanelDisplay = '';
 
     const updateClock = () => {
         const now = new Date();
         const hours = is24HourFormat ? now.getHours() : now.getHours() % 12 || 12;
         const minutes = now.getMinutes().toString().padStart(2, '0');
         const seconds = now.getSeconds().toString().padStart(2, '0');
-        const ampm = !is24HourFormat && now.getHours() >= 12 ? ' PM' : ' AM';
+        const ampm = !is24HourFormat ? now.getHours() >= 12 ? ' PM' : ' AM' : '';
 
-        clock.innerHTML = `${hours.toString().padStart(2, '0')}:${minutes}:${seconds}${!is24HourFormat ? ampm : ''}`;
+        clock.innerHTML = `${hours.toString().padStart(2, '0')}:${minutes}:${seconds}${ampm}`;
     };
 
     const toggleFormat = () => {
         is24HourFormat = !is24HourFormat;
         toggleFormatButton.textContent = is24HourFormat ? 'Switch to 12-Hour Format' : 'Switch to 24-Hour Format';
+        localStorage.setItem('is24HourFormat', is24HourFormat);
         updateClock();
     };
 
     const changeColorMode = (e) => {
         colorMode = e.target.value;
+        localStorage.setItem('colorMode', colorMode);
         document.body.className = colorMode;
         if (colorMode === 'dynamic-color') {
             startDynamicColorChange();
@@ -67,30 +69,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const toggleFullscreen = () => {
         if (!document.fullscreenElement) {
+            prevPanelDisplay = settingsPanel.style.display;
+            settingsPanel.style.display = 'none';
             document.documentElement.requestFullscreen().then(() => {
                 document.body.classList.add('fullscreen');
-                footer.style.display = 'none'; // Hide footer in fullscreen mode
+                footer.style.display = 'none';
             }).catch((err) => {
+                settingsPanel.style.display = prevPanelDisplay;
                 console.error(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`);
             });
         } else {
             document.exitFullscreen().then(() => {
                 document.body.classList.remove('fullscreen');
-                footer.style.display = ''; // Show footer in normal mode
+                footer.style.display = '';
+                if (prevPanelDisplay === 'block') {
+                    settingsPanel.style.display = 'block';
+                }
             }).catch((err) => {
                 console.error(`Error attempting to disable full-screen mode: ${err.message} (${err.name})`);
             });
         }
     };
 
-    // Add fullscreenchange event listener
     document.addEventListener('fullscreenchange', () => {
         if (document.fullscreenElement) {
+            prevPanelDisplay = settingsPanel.style.display;
+            settingsPanel.style.display = 'none';
             document.body.classList.add('fullscreen');
-            footer.style.display = 'none'; // Hide footer in fullscreen mode
+            footer.style.display = 'none';
         } else {
             document.body.classList.remove('fullscreen');
-            footer.style.display = ''; // Show footer in normal mode
+            footer.style.display = '';
+            if (prevPanelDisplay === 'block') {
+                settingsPanel.style.display = 'block';
+            }
         }
     });
 
@@ -112,6 +124,22 @@ document.addEventListener('DOMContentLoaded', () => {
         fontSizeSlider.value = '80';
         fontSizeValue.textContent = '80px';
         clock.style.fontSize = '80px';
+    }
+
+    const savedFormat = localStorage.getItem('is24HourFormat');
+    if (savedFormat !== null) {
+        is24HourFormat = savedFormat === 'true';
+        toggleFormatButton.textContent = is24HourFormat ? 'Switch to 12-Hour Format' : 'Switch to 24-Hour Format';
+    }
+
+    const savedColorMode = localStorage.getItem('colorMode');
+    if (savedColorMode && savedColorMode !== colorMode) {
+        colorModeSelect.value = savedColorMode;
+        colorMode = savedColorMode;
+        document.body.className = colorMode;
+        if (colorMode === 'dynamic-color') {
+            startDynamicColorChange();
+        }
     }
 
     updateClock();

--- a/w/lc/styles.css
+++ b/w/lc/styles.css
@@ -31,14 +31,15 @@ body {
 
 /* Footer Styles */
 footer {
-    text-align: center;
-    padding: 10px;
-    font-size: 0.875rem;
-    position: absolute;
+    position: fixed;
     bottom: 0;
     left: 50%;
     transform: translateX(-50%);
-    transition: opacity 0.3s; /* Smooth transition for visibility */
+    width: 100%;
+    text-align: center;
+    padding: 10px;
+    font-size: 0.875rem;
+    transition: opacity 0.3s;
 }
 
 /* Fullscreen Mode Styles */
@@ -100,27 +101,15 @@ button:active, select:active {
 
 /* Settings Panel Styles */
 .settings-panel {
-    background-color: var(--bg-secondary);
-    border-radius: 12px;
-    padding: 1.5rem;
-    box-shadow: var(--box-shadow);
-    transform: translateY(0);
-    transition: all 0.3s;
-    display: flex;
+    display: none;
     flex-direction: column;
     align-items: center;
-    padding: 15px;
-    border-radius: 8px;
     background: rgba(0, 0, 0, 0.8);
     color: #fff;
-    display: none;
+    padding: 15px;
+    border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
-}
-
-.settings-panel.hidden {
-    transform: translateY(20px);
-    opacity: 0;
-    pointer-events: none;
+    transition: all 0.3s;
 }
 
 .settings-panel h3 {


### PR DESCRIPTION
Fixes across w/lc/clock:

1. Settings toggle - first click now opens panel (was requiring double-click)
2. Fullscreen - panel hides on enter, restores on exit (even via Escape)
3. Persistence - 24h/12h format + color mode saved to localStorage
4. Dead code - removed unused IntersectionObserver + container variable
5. CSS - merged duplicate .settings-panel rules, removed dead .hidden class
6. HTML - moved stray div into body
7. Footer - CSS position aligned to inline style (fixed)
8. Font default - slider and applied size now consistent (80px)
9. AM/PM - only computed in 12h mode
10. var leak - fontSize properly scoped with const