### PR TITLE
feat: static news page rendering from streams.js data

### DIFF
--- a/w/youtube-news/news.html
+++ b/w/youtube-news/news.html
@@ -191,167 +191,83 @@
         <div class="multi-view-grid" id="multi-view-grid"></div>
     </div>
     
-        <div class="channel">
-            <div class="channel-name">News 18 Tamil Nadu (@News18Tamilnadu)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="UEEptD-Rm8o" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/UEEptD-Rm8o" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="cuRN3CP7CsY" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/cuRN3CP7CsY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="E4ndYFfdlb8" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/E4ndYFfdlb8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">Polimer News (@PolimerNews)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="BMdTXFenR3I" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/BMdTXFenR3I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="-AdTXTXvsh0" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/-AdTXTXvsh0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="BGSIWe4SaOo" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/BGSIWe4SaOo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">News Tamil 24 x 7 (@NewsTamil24X7TV)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="ptyG6tSsSWY" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/ptyG6tSsSWY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="3BRAJBI5CzE" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/3BRAJBI5CzE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="gynWNinqmjw" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/gynWNinqmjw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">Satiyam TV (@SathiyamTV)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="KB3H7bfeSVw" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/KB3H7bfeSVw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="RTXWatEKRl4" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/RTXWatEKRl4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="z4_I7yNtW5U" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/z4_I7yNtW5U" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="-8_V7EbnRiw" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/-8_V7EbnRiw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">Thanthi TV (@thanthitv)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="4UMPJsEbSMQ" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/4UMPJsEbSMQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="XrR1QUUl64w" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/XrR1QUUl64w" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="O-UZiDNCa0Y" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/O-UZiDNCa0Y" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="_Lg0IUxUMi0" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/_Lg0IUxUMi0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">புதிய தலைமுறை | PuthiyathalaimuraiTV (@PuthiyaThalaimuraiTV)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="kgq2-4c_FX0" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/kgq2-4c_FX0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="Yd4Su5dV5zE" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/Yd4Su5dV5zE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="hw7Fjh6mncQ" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/hw7Fjh6mncQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">Sun News Tamil (@Sunnewstamil)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="XKXLGT9C46k" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/XKXLGT9C46k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="9M02G5c6x6w" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/9M02G5c6x6w" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">Kalaignar TV News (@KalaignarTVNews)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="GFe5klT848Q" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/GFe5klT848Q" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr>
-        <div class="channel">
-            <div class="channel-name">News J (@NewsJ)</div>
-        <div class="live-streams">
-        
-        <div class="live-stream">
-            <input type="checkbox" class="stream-select" value="x1M7MOQ01AE" title="Select for multi fullscreen" aria-label="Select stream for multi fullscreen">
-            <iframe data-src="https://www.youtube-nocookie.com/embed/x1M7MOQ01AE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        </div></div><hr><div style="text-align: center;">Last updated on 2026-08-16 10:15:24 IST</div><hr>
+                <div id="channel-sections"></div>
+
+
     <div class="channel custom-streams-section" id="custom-streams-section" hidden>
         <div class="channel-name">Custom Streams</div>
         <div class="live-streams" id="custom-streams"></div>
     </div>
-    <script>
+            <script src="streams.js"></script>
+        <script>
+            // Render live channels from window.YTN_STREAMS (published by the pipeline).
+            // No fallback data: empty/missing data renders an empty state only.
+            (function () {
+                const container = document.getElementById('channel-sections');
+                const data = window.YTN_STREAMS || null;
+
+                const makeStreamCard = (streamId) => {
+                    const div = document.createElement('div');
+                    div.className = 'live-stream';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.className = 'stream-select';
+                    checkbox.value = streamId;
+                    checkbox.title = 'Select for multi fullscreen';
+                    checkbox.setAttribute('aria-label', 'Select stream for multi fullscreen');
+
+                    const iframe = document.createElement('iframe');
+                    iframe.setAttribute('data-src', 'https://www.youtube-nocookie.com/embed/' + streamId);
+                    iframe.setAttribute('frameborder', '0');
+                    iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
+                    iframe.setAttribute('allowfullscreen', '');
+
+                    div.appendChild(checkbox);
+                    div.appendChild(iframe);
+                    return div;
+                };
+
+                const makeChannelSection = (channel) => {
+                    const section = document.createElement('div');
+                    section.className = 'channel';
+
+                    const name = document.createElement('div');
+                    name.className = 'channel-name';
+                    name.textContent = channel.name + ' (' + channel.handle + ')';  // textContent — XSS-safe
+
+                    const streams = document.createElement('div');
+                    streams.className = 'live-streams';
+                    (channel.streams || []).forEach((id) => streams.appendChild(makeStreamCard(id)));
+
+                    section.appendChild(name);
+                    section.appendChild(streams);
+                    return section;
+                };
+
+                if (!container) return;
+
+                if (!data || !Array.isArray(data.channels) || data.channels.length === 0) {
+                    const empty = document.createElement('div');
+                    empty.className = 'channel-name';
+                    empty.textContent = 'No live streams right now';
+                    container.appendChild(empty);
+                    return;
+                }
+
+                data.channels.forEach((channel) => container.appendChild(makeChannelSection(channel)));
+
+                const updated = document.createElement('div');
+                updated.style.textAlign = 'center';
+                // generated_at is ISO (2026-08-16T10:53:32+0530) -> display as before: 2026-08-16 10:53:32 IST
+                const g = data.generated_at || '';
+                const m = g.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})([+-]\d{4})?$/);
+                updated.textContent = g ? 'Last updated on ' + (m ? m[1] + ' ' + m[2] + ' IST' : g) : '';
+                container.appendChild(updated);
+            })();
+        </script>
+
+<script>
         document.addEventListener("DOMContentLoaded", function() {
             const iframes = document.querySelectorAll('iframe[data-src]');
             const CUSTOM_STREAMS_STORAGE_KEY = 'yt-news-custom-stream-ids';


### PR DESCRIPTION
Private pipeline now publishes only stream data (u-tube-news PR #45 -> auto-PR #2088 added w/youtube-news/streams.js). This page renders it client-side: design stays in this repo from now on, pipeline never touches it.

- Replaces hardcoded channel sections with a renderer reading window.YTN_STREAMS
- XSS-safe DOM building (textContent, per repo convention)
- Empty state when no data (no fallback)
- Multi-view fullscreen + custom streams + footer unchanged